### PR TITLE
feat: allow transpile of ts files

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,4 @@
 {
-    "extends": "@krakenjs/grumbler-scripts/config/.babelrc-node"
+    "extends": "@krakenjs/grumbler-scripts/config/.babelrc-node",
+    "presets": ["@krakenjs/grumbler-scripts/config/flow-ts-babel-preset"]
 }


### PR DESCRIPTION
This library runs `babel-register` when spawning a child_process. This preset allows `*.(ts|tsx)` to be transpiled via `grumbler-scripts`