### PR TITLE
feat: add `useTypeScriptRegister` as an optional param to `spawnProcess`

### DIFF
--- a/src/process/master.js
+++ b/src/process/master.js
@@ -47,14 +47,19 @@ export function messageWorker<M: mixed, R: mixed>(
 
 type SpawnOptions = {|
   script?: string,
+  useTypeScriptRegister?: boolean,
 |};
 
-export function spawnProcess({ script }: SpawnOptions = {}): SpawnedProcess {
+export function spawnProcess({
+  script,
+  useTypeScriptRegister,
+}: SpawnOptions = {}): SpawnedProcess {
   let worker;
   const onDisconnectHandlers = [];
   const onErrorHandlers = [];
   const onCloseHandlers = [];
-  const isTypeScript = path.extname(script || "").includes(".ts");
+  const isTypeScript =
+    useTypeScriptRegister || path.extname(script || "").includes(".ts");
   const spawnOpts = {
     stdio: [null, null, null, "ipc"],
     env: {

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -33,3 +33,22 @@ test(`Should successfully call a function on a different process with typescript
 
   worker.kill();
 });
+
+test("Should successfully call a function on a different process with `useTypeScriptRegister=true`", async () => {
+  const worker = spawnProcess({
+    script: require.resolve("./childTypescript"),
+    useTypeScriptRegister: true,
+  });
+
+  let called = false;
+
+  await worker.send("call", () => {
+    called = true;
+  });
+
+  if (!called) {
+    throw new Error(`Expected function to be called`);
+  }
+
+  worker.kill();
+});


### PR DESCRIPTION
there were some more interesting usecases where its useful to identify
the process as a typescript process before attaching to the process and
this can be a handy option to leverage in those cases